### PR TITLE
Handle nil tailscale client in metrics gathering

### DIFF
--- a/main.go
+++ b/main.go
@@ -248,6 +248,10 @@ func runServe(ctx context.Context, tsClient *tailscale.Client, tsServer *tsnet.S
 }
 
 func gatherMetrics(ctx context.Context, client *tailscale.Client) error {
+	if client == nil {
+		return fmt.Errorf("tailscale client not configured")
+	}
+
 	devices, err := client.Devices().List(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
- return an error when the Tailscale API client is not configured

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go build ./...`
- `golangci-lint run ./...`


------
https://chatgpt.com/codex/tasks/task_e_688e903786c48326a6641d2e5209d53e