### PR TITLE
feat: auto-detect mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ All CLI options can be configured via environment variables:
 - `TS_EXPORTER_PUSHGATEWAY_RETRIES` - Pushgateway retry count
 - `TS_EXPORTER_MODE` - Default subcommand (`serve` or `generate`)
 
+When no mode is provided, the exporter will automatically run in `serve`
+mode when `LISTEN_PID` is set or in `generate` mode when `TRIGGER_UNIT` is
+set. If neither is detected, it exits with an error.
+
 ## Credential Loading
 
 The exporter supports loading credentials from files or a credentials directory:

--- a/main.go
+++ b/main.go
@@ -87,7 +87,16 @@ type mainCommand struct {
 
 func main() {
 	if len(os.Args) == 1 || strings.HasPrefix(os.Args[1], "-") {
-		if mode := os.Getenv("TS_EXPORTER_MODE"); mode != "" {
+		mode := os.Getenv("TS_EXPORTER_MODE")
+		if mode == "" {
+			switch {
+			case os.Getenv("LISTEN_PID") != "":
+				mode = "serve"
+			case os.Getenv("TRIGGER_UNIT") != "":
+				mode = "generate"
+			}
+		}
+		if mode != "" {
 			os.Args = append([]string{os.Args[0], mode}, os.Args[1:]...)
 		}
 	}


### PR DESCRIPTION
## Summary
- detect `serve` mode when `LISTEN_PID` is present
- detect `generate` mode when `TRIGGER_UNIT` is set
- document automatic mode detection logic

## Testing
- `go mod download`
- `go fmt ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_688e908c9f6083269165857fba23ac98